### PR TITLE
Show avatar with hat/helm

### DIFF
--- a/src/sampler/meta.js
+++ b/src/sampler/meta.js
@@ -39,7 +39,7 @@ const CommonMetadata = ({ metadata }) => {
         let avatarUrl;
         if (user.type === CommandSenderData.Type.PLAYER.value) {
             const uuid = user.uniqueId.replace(/-/g, '');
-            avatarUrl = 'https://crafthead.net/avatar/' + uuid + '/20.png';
+            avatarUrl = 'https://crafthead.net/helm/' + uuid + '/20.png';
         } else {
             avatarUrl = 'https://crafthead.net/avatar/Console/20.png';
         }


### PR DESCRIPTION
The [Luckperms webeditor](https://github.com/LuckPerms/LuckPermsWeb/blob/master/src/components/Avatar.vue#L4) already uses the avatar variant with hat/helm. The spark viewer doesn't do this, which can lead to some skins looking weird if they're designed to be viewed with the hat layer enabled.