### PR TITLE
Save current view to localStorage

### DIFF
--- a/src/sampler/controls.js
+++ b/src/sampler/controls.js
@@ -52,14 +52,18 @@ const ToggleViewButton = ({ data, view, setView }) => {
     function onClick() {
         if (view === VIEW_ALL) {
             setView(VIEW_FLAT);
+            localStorage.setItem("view", "VIEW_FLAT");
         } else if (view === VIEW_FLAT) {
             if (Object.keys(data.classSources).length) {
                 setView(VIEW_SOURCES);
+                localStorage.setItem("view", "VIEW_SOURCES");
             } else {
                 setView(VIEW_ALL);
+                localStorage.removeItem("view");
             }
         } else {
             setView(VIEW_ALL);
+            localStorage.removeItem("view");
         }
     }
 

--- a/src/sampler/index.js
+++ b/src/sampler/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { AllView, FlatView, SourcesView, VIEW_ALL, VIEW_FLAT } from './views';
+import { AllView, FlatView, SourcesView, VIEW_ALL, VIEW_FLAT, VIEW_SOURCES } from './views';
 import Controls from './controls';
 import Flame from './flamegraph';
 import { WidgetsAndMetadata } from '../viewer/meta';
@@ -19,8 +19,10 @@ export default function Sampler({ data, mappings, exportCallback }) {
     const searchQuery = useSearchQuery();
     const highlighted = useHighlight();
 
+    const cachedView = localStorage.view;
+
     const [flameData, setFlameData] = useState(null);
-    const [view, setView] = useState(VIEW_ALL);
+    const [view, setView] = useState((cachedView === 'VIEW_FLAT' ? VIEW_FLAT : cachedView === 'VIEW_SOURCES' ? VIEW_SOURCES : VIEW_ALL));
 
     const [flatViewData, setFlatViewData] = useState({
         flatSelfTime: null,


### PR DESCRIPTION
With this PR, the current view will now be saved to `localStorage` for later use. I also did this because I mainly only use the sources view.