### PR TITLE
Increase avatar size to 24px

### DIFF
--- a/src/viewer/common/components/Avatar.tsx
+++ b/src/viewer/common/components/Avatar.tsx
@@ -11,9 +11,9 @@ export default function Avatar({ user }: AvatarProps) {
     let avatarUrl;
     if (user.type === CommandSenderMetadata_Type.PLAYER) {
         const uuid = user.uniqueId.replace(/-/g, '');
-        avatarUrl = 'https://crafthead.net/helm/' + uuid + '/20.png';
+        avatarUrl = 'https://crafthead.net/helm/' + uuid + '/24.png';
     } else {
-        avatarUrl = 'https://crafthead.net/avatar/Console/20.png';
+        avatarUrl = 'https://crafthead.net/avatar/Console/24.png';
     }
 
     return <img src={avatarUrl} alt="" />;


### PR DESCRIPTION
This PR increases avatar sizes in the spark viewer from 20px to 24px. It may seem like a pointless change, but it significantly improves the rendering of pixel-perfect avatars. Minecraft faces are 8x8, so when scaled to 20px using pixel perfect scaling some avatars come out looking a bit distorted. Here is an example of my skin's face before and after this change.

Before (notice how the two legs are not the same, and the design doesn't look perfectly centered):

![image](https://github.com/lucko/spark-viewer/assets/42941056/dfb03242-b9ea-4352-8c70-21d4922d1588)

After: 

![image](https://github.com/lucko/spark-viewer/assets/42941056/aa8cfca7-b28a-423b-ba78-6aab73ed4a0a)
