### PR TITLE
feat: add online status to thumbnail

### DIFF
--- a/src/viewer/common/components/Thumbnail.tsx
+++ b/src/viewer/common/components/Thumbnail.tsx
@@ -12,6 +12,7 @@ import styles from '../../../style/thumbnail.module.scss';
 import { SparkMetadata } from '../../proto/guards';
 import {
     PlatformMetadata_Type,
+    PlatformStatistics_OnlineMode,
     SamplerMetadata_SamplerMode,
 } from '../../proto/spark_pb';
 import { SparkContentType } from '../logic/contentType';
@@ -58,6 +59,7 @@ export default function Thumbnail({ metadata, code, type }: ThumbnailProps) {
     }
 
     const platformType = PlatformMetadata_Type[platform.type].toLowerCase();
+    const onlineMode = platformStatistics ? ` (${PlatformStatistics_OnlineMode[platformStatistics?.onlineMode].toLowerCase()})` : "";
 
     const { runningTime, numberOfTicks, samplerMode } =
         unwrapSamplerMetadata(metadata);
@@ -96,6 +98,7 @@ export default function Thumbnail({ metadata, code, type }: ThumbnailProps) {
                     <span>{platform.brand || platform.name}</span>{' '}
                     {platformType} &quot;
                     <span>{platform.version}</span>&quot;
+                    {onlineMode}
                 </p>
                 {!!platformStatistics?.playerCount && (
                     <p>


### PR DESCRIPTION
Example:
![image](https://github.com/user-attachments/assets/2966d61e-e6f9-4a0c-b8f6-1c04d718917e)

This was added to allow support servers the ability to decide whether to offer support at a glance as a lot of people would prefer not to offer support to people running offline servers without a proxy.