### PR TITLE
chore: Auto-expand nodes when filtered nodes <=1

### DIFF
--- a/src/viewer/sampler/components/tree/BaseNode.tsx
+++ b/src/viewer/sampler/components/tree/BaseNode.tsx
@@ -41,11 +41,16 @@ const BaseNode = React.memo(({ parents, node, forcedTime }: BaseNodeProps) => {
         if (highlighted.check(node)) {
             return true;
         }
-        if (bottomUp) {
-            return directParent && directParent.getParents().length === 1;
-        } else {
-            return directParent && directParent.getChildren().length === 1;
+        if (directParent == null) {
+            return false;
         }
+
+        const nodes = bottomUp
+            ? directParent.getParents()
+            : directParent.getChildren();
+
+        const count = nodes.filter(n => searchQuery.matches(n)).length;
+        return count <= 1;
     });
 
     const parentsForChildren = useMemo(


### PR DESCRIPTION
This makes the node auto-expand feature work when you have a search term active