### PR TITLE
add "return to sampler" button

### DIFF
--- a/src/viewer/sampler/components/Sampler.tsx
+++ b/src/viewer/sampler/components/Sampler.tsx
@@ -181,6 +181,9 @@ export default function Sampler({
                     mappings={mappings.mappingsResolver}
                     metadata={metadata}
                     timeSelector={timeSelector}
+                    onReturnToSampler={(node: VirtualNode) => {
+                        console.log("HELLO");
+                    }}
                 />
             )}
 

--- a/src/viewer/sampler/components/Sampler.tsx
+++ b/src/viewer/sampler/components/Sampler.tsx
@@ -184,11 +184,13 @@ export default function Sampler({
                     metadata={metadata}
                     timeSelector={timeSelector}
                     onReturnToSampler={(node: VirtualNode) => {
-                        expanded.clearAll();
+                        expanded.clearAll(); // fold all nodes
+                        // Expand selected node and its parents
                         while (node != null) {
                             expanded.set(node, true);
                             node = node.getParents()[0];
                         }
+                        // Return to sampler view
                         setFlameData(undefined);
                     }}
                 />

--- a/src/viewer/sampler/components/Sampler.tsx
+++ b/src/viewer/sampler/components/Sampler.tsx
@@ -27,6 +27,7 @@ import AllView from './views/AllView';
 import FlatView from './views/FlatView';
 import SourcesView from './views/SourcesView';
 import { View, VIEW_ALL, VIEW_FLAT } from './views/types';
+import useExpanded from '../hooks/useExpanded';
 
 const Graph = dynamic(() => import('./graph/Graph'));
 
@@ -53,6 +54,7 @@ export default function Sampler({
 }: SamplerProps) {
     const searchQuery = useSearchQuery(data);
     const highlighted = useHighlight();
+    const expanded = useExpanded(searchQuery, highlighted);
     const [labelMode, setLabelMode] = useState(false);
     const timeSelector = useTimeSelector(
         data.timeWindows,
@@ -182,7 +184,12 @@ export default function Sampler({
                     metadata={metadata}
                     timeSelector={timeSelector}
                     onReturnToSampler={(node: VirtualNode) => {
-                        console.log("HELLO");
+                        expanded.clearAll();
+                        while (node != null) {
+                            expanded.set(node, true);
+                            node = node.getParents()[0];
+                        }
+                        setFlameData(undefined);
                     }}
                 />
             )}
@@ -192,6 +199,7 @@ export default function Sampler({
                     mappings={mappings.mappingsResolver}
                     infoPoints={infoPoints}
                     highlighted={highlighted}
+                    expanded={expanded}
                     searchQuery={searchQuery}
                     labelMode={labelMode}
                     metadata={metadata}

--- a/src/viewer/sampler/components/SamplerContext.tsx
+++ b/src/viewer/sampler/components/SamplerContext.tsx
@@ -5,6 +5,7 @@ import { InfoPointsHook } from '../hooks/useInfoPoints';
 import { SearchQuery } from '../hooks/useSearchQuery';
 import { TimeSelector } from '../hooks/useTimeSelector';
 import { MappingsResolver } from '../mappings/resolver';
+import { Expanded } from '../hooks/useExpanded';
 
 export const MappingsContext = createContext<MappingsResolver | undefined>(
     undefined
@@ -25,11 +26,13 @@ export const LabelModeContext = createContext<boolean>(false);
 export const TimeSelectorContext = createContext<TimeSelector | undefined>(
     undefined
 );
+export const ExpandedContext = createContext<Expanded | undefined>(undefined);
 
 export default function SamplerContext({
     mappings,
     infoPoints,
     highlighted,
+    expanded,
     searchQuery,
     labelMode,
     metadata,
@@ -39,6 +42,7 @@ export default function SamplerContext({
     mappings: MappingsResolver;
     infoPoints: InfoPointsHook;
     highlighted: Highlight;
+    expanded: Expanded;
     searchQuery: SearchQuery;
     labelMode: boolean;
     metadata: SamplerMetadata;
@@ -51,15 +55,15 @@ export default function SamplerContext({
             <InfoPointsContext.Provider value={infoPoints}>
                 <HighlightedContext.Provider value={highlighted}>
                     <SearchQueryContext.Provider value={searchQuery}>
-                        <LabelModeContext.Provider value={labelMode}>
-                            <MetadataContext.Provider value={metadata}>
-                                <TimeSelectorContext.Provider
-                                    value={timeSelector}
-                                >
-                                    {children}
-                                </TimeSelectorContext.Provider>
-                            </MetadataContext.Provider>
-                        </LabelModeContext.Provider>
+                        <ExpandedContext.Provider value={expanded}>
+                            <LabelModeContext.Provider value={labelMode}>
+                                <MetadataContext.Provider value={metadata}>
+                                    <TimeSelectorContext.Provider value={timeSelector}>
+                                        {children}
+                                    </TimeSelectorContext.Provider>
+                                </MetadataContext.Provider>
+                            </LabelModeContext.Provider>
+                        </ExpandedContext.Provider>
                     </SearchQueryContext.Provider>
                 </HighlightedContext.Provider>
             </InfoPointsContext.Provider>

--- a/src/viewer/sampler/components/flamegraph/Flame.tsx
+++ b/src/viewer/sampler/components/flamegraph/Flame.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { FlameGraph } from '@lucko/react-flame-graph';
-import { useMemo } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { AutoSizer } from 'react-virtualized';
 import { formatBytesShort } from '../../../common/util/format';
 import {
@@ -10,12 +10,16 @@ import {
 import { TimeSelector } from '../../hooks/useTimeSelector';
 import { MappingsResolver } from '../../mappings/resolver';
 import VirtualNode from '../../node/VirtualNode';
+import { Menu, Item, ItemParams } from 'react-contexify';
+import { useContextMenu } from 'react-contexify';
+import 'react-contexify/dist/ReactContexify.css';
 
 export interface FlameProps {
     flameData: VirtualNode;
     mappings: MappingsResolver;
     metadata: SamplerMetadata;
     timeSelector: TimeSelector;
+    onReturnToSampler?: (node: VirtualNode) => void;
 }
 
 export default function Flame({
@@ -23,8 +27,11 @@ export default function Flame({
     mappings,
     metadata,
     timeSelector,
+    onReturnToSampler,
 }: FlameProps) {
     const getTimeFunction = timeSelector.getTime;
+    const flameRef = useRef<HTMLDivElement>(null);
+    const { show } = useContextMenu({ id: 'flame-cm' });
 
     const isAlloc =
         metadata.samplerMode === SamplerMetadata_SamplerMode.ALLOCATION;
@@ -35,13 +42,47 @@ export default function Flame({
     );
     const calcHeight = Math.min(depth * 20, 5000);
 
+    const [selectedNode, setSelectedNode] = useState<VirtualNode | null>(null);
+
+    // Handler for context menu on the main div
+    function handleDivContextMenu(event: React.MouseEvent) {
+        event.preventDefault();
+        if (selectedNode) {
+            show({ event, props: { node: selectedNode } });
+        }
+    }
+
+    // Handler for mouse over on FlameGraph
+    function handleMouseOver(flameNode: any) {
+        if (flameNode && flameNode.virtualNode) {
+            setSelectedNode(flameNode.virtualNode);
+        } else {
+            setSelectedNode(null);
+        }
+    }
+
     return (
-        <div className="flame" style={{ height: `${calcHeight}px` }}>
+        <div
+            className="flame"
+            style={{ height: `${calcHeight}px` }}
+            ref={flameRef}
+            onContextMenu={handleDivContextMenu}
+        >
             <AutoSizer>
-                {({ width }) => (
-                    <FlameGraph data={data} height={calcHeight} width={width} />
+                {({ width }: { width: number }) => (
+                    <FlameGraph
+                        data={data}
+                        height={calcHeight}
+                        width={width}
+                        onMouseOver={(_e: any, node: any) => handleMouseOver(node)}
+                    />
                 )}
             </AutoSizer>
+            <Menu id="flame-cm" theme="dark">
+                <Item onClick={({ props }: ItemParams<{ node: VirtualNode }>) => props?.node && onReturnToSampler && onReturnToSampler(props.node)}>
+                    View in sampler
+                </Item>
+            </Menu>
         </div>
     );
 }
@@ -51,6 +92,7 @@ interface FlameNode {
     tooltip?: string;
     value: number;
     children: FlameNode[];
+    virtualNode: VirtualNode;
 }
 
 function toFlameNode(
@@ -114,7 +156,7 @@ function toFlameNode(
         children.push(childData);
     }
 
-    return [{ name, tooltip, value, children }, depth];
+    return [{ name, tooltip, value, children, virtualNode: node }, depth];
 }
 
 function simplifyPackageName(

--- a/src/viewer/sampler/components/flamegraph/Flame.tsx
+++ b/src/viewer/sampler/components/flamegraph/Flame.tsx
@@ -19,7 +19,7 @@ export interface FlameProps {
     mappings: MappingsResolver;
     metadata: SamplerMetadata;
     timeSelector: TimeSelector;
-    onReturnToSampler?: (node: VirtualNode) => void;
+    onReturnToSampler: (node: VirtualNode) => void;
 }
 
 export default function Flame({
@@ -44,7 +44,6 @@ export default function Flame({
 
     const [selectedNode, setSelectedNode] = useState<VirtualNode | null>(null);
 
-    // Handler for context menu on the main div
     function handleDivContextMenu(event: React.MouseEvent) {
         event.preventDefault();
         if (selectedNode) {
@@ -52,7 +51,6 @@ export default function Flame({
         }
     }
 
-    // Handler for mouse over on FlameGraph
     function handleMouseOver(flameNode: any) {
         if (flameNode && flameNode.virtualNode) {
             setSelectedNode(flameNode.virtualNode);
@@ -79,7 +77,7 @@ export default function Flame({
                 )}
             </AutoSizer>
             <Menu id="flame-cm" theme="dark">
-                <Item onClick={({ props }: ItemParams<{ node: VirtualNode }>) => props?.node && onReturnToSampler && onReturnToSampler(props.node)}>
+                <Item onClick={({ props }: ItemParams<{ node: VirtualNode }>) => props?.node && onReturnToSampler(props.node)}>
                     View in sampler
                 </Item>
             </Menu>

--- a/src/viewer/sampler/components/tree/BaseNode.tsx
+++ b/src/viewer/sampler/components/tree/BaseNode.tsx
@@ -52,6 +52,7 @@ const BaseNode = React.memo(({ parents, node, forcedTime }: BaseNodeProps) => {
         const count = nodes.filter(n => searchQuery.matches(n)).length;
         return count <= 1;
     });
+    node.setExpanded = setExpanded;
 
     const parentsForChildren = useMemo(
         () => parents.concat([node]),

--- a/src/viewer/sampler/hooks/useExpanded.ts
+++ b/src/viewer/sampler/hooks/useExpanded.ts
@@ -40,14 +40,19 @@ export default function useExpanded(searchQuery: SearchQuery, highlighted: Highl
 
     // Get expanded state, or default (sometimes, nodes should be expanded by default)
     const getOrDefault: Expanded['getOrDefault'] = (node, directParent, bottomUp) => {
+        // Try to get value from map first
         const value = get(node);
         if (value !== undefined) return value;
-        // Inline auto-expand logic here
+
+        // auto-expand logic
+
         if (highlighted.check(node)) return true;
+
         if (directParent == null) return false;
         let nodes;
         if (bottomUp) nodes = directParent.getParents();
         else nodes = directParent.getChildren();
+
         nodes = nodes.filter(n => searchQuery.matches(n));
         return nodes.length <= 1;
     };

--- a/src/viewer/sampler/hooks/useExpanded.ts
+++ b/src/viewer/sampler/hooks/useExpanded.ts
@@ -1,0 +1,70 @@
+import { useCallback, useState } from 'react';
+import VirtualNode from '../node/VirtualNode';
+import { SearchQuery } from './useSearchQuery';
+import { Highlight } from './useHighlight';
+
+export interface Expanded {
+    set: (node: VirtualNode, value: boolean | undefined) => void;
+    get: (node: VirtualNode) => boolean | undefined;
+    getOrDefault: (node: VirtualNode, directParent: VirtualNode | null, bottomUp: boolean) => boolean;
+    toggle: (node: VirtualNode) => void;
+    clearAll: () => void;
+}
+
+export default function useExpanded(searchQuery: SearchQuery, highlighted: Highlight): Expanded {
+    const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
+
+    // Set expanded state for a node
+    const set: Expanded['set'] = useCallback(
+        (node, value) => {
+            setExpanded(prev => {
+                const map = new Map(prev);
+                if (value === undefined) {
+                    map.delete(String(node.getId()));
+                } else {
+                    map.set(String(node.getId()), value);
+                }
+                return map;
+            });
+        },
+        []
+    );
+
+    // Get expanded state for a node
+    const get: Expanded['get'] = useCallback(
+        node => {
+            return expanded.get(String(node.getId()));
+        },
+        [expanded]
+    );
+
+    // Get expanded state, or default (sometimes, nodes should be expanded by default)
+    const getOrDefault: Expanded['getOrDefault'] = (node, directParent, bottomUp) => {
+        const value = get(node);
+        if (value !== undefined) return value;
+        // Inline auto-expand logic here
+        if (highlighted.check(node)) return true;
+        if (directParent == null) return false;
+        let nodes;
+        if (bottomUp) nodes = directParent.getParents();
+        else nodes = directParent.getChildren();
+        nodes = nodes.filter(n => searchQuery.matches(n));
+        return nodes.length <= 1;
+    };
+
+    // Toggle expanded state for a node
+    const toggle: Expanded['toggle'] = useCallback(
+        node => {
+            set(node, !get(node));
+        },
+        [set, get]
+    );
+
+    // Clear all expanded nodes
+    const clearAll: Expanded['clearAll'] = useCallback(
+        () => setExpanded(new Map()),
+        []
+    );
+
+    return { set, get, getOrDefault, toggle, clearAll };
+}

--- a/src/viewer/sampler/node/VirtualNode.ts
+++ b/src/viewer/sampler/node/VirtualNode.ts
@@ -1,5 +1,7 @@
 import { NodeDetails } from '../../proto/nodes';
 
+// represents the data of a node (frame)
+// One instance per ConcreteClass::method, meaning LivingEntity::tick() can have multiple virtual nodes, one per living entity
 export default interface VirtualNode {
     getId(): number | number[];
 
@@ -14,6 +16,4 @@ export default interface VirtualNode {
     getParents(): VirtualNode[];
 
     getSource(): string | undefined;
-
-    setExpanded?(expanded: boolean): void;
 }

--- a/src/viewer/sampler/node/VirtualNode.ts
+++ b/src/viewer/sampler/node/VirtualNode.ts
@@ -14,4 +14,6 @@ export default interface VirtualNode {
     getParents(): VirtualNode[];
 
     getSource(): string | undefined;
+
+    setExpanded?(expanded: boolean): void;
 }


### PR DESCRIPTION
You access that button by right-clicking on any node, and it will return to the sampler while expanding the selected node

Future extension of this: highlight (like, a temporary glow effect) the node selected when returning to the sampler