### PR TITLE
Show allocation label toggle on proxy profilers

### DIFF
--- a/src/viewer/sampler/components/views/button/LabelModeButton.tsx
+++ b/src/viewer/sampler/components/views/button/LabelModeButton.tsx
@@ -13,11 +13,14 @@ export default function LabelModeButton({
     setLabelMode,
 }: LabelModeButtonProps) {
     const metadata = useContext(MetadataContext)!;
-    if (!metadata.numberOfTicks) {
+    const isAllocationProfile =
+        metadata.samplerMode === SamplerMetadata_SamplerMode.ALLOCATION;
+
+    if (!isAllocationProfile && !metadata.numberOfTicks) {
         return null;
     }
 
-    if (metadata.samplerMode === SamplerMetadata_SamplerMode.ALLOCATION) {
+    if (isAllocationProfile) {
         return (
             <Button
                 value={labelMode}


### PR DESCRIPTION
Bytes per second should always be an option for allocation profilers