### PR TITLE
Fix crash when the profile is updated in the sources view

### DIFF
--- a/src/viewer/sampler/components/Sampler.tsx
+++ b/src/viewer/sampler/components/Sampler.tsx
@@ -73,10 +73,14 @@ export default function Sampler({
 
     // views reference nodes by id so keep them tied to their data
     // otherwise old ids gets resolved against the new node map
-    const [flatViewData, setFlatViewData] =
-        useState<[SamplerData, FlatViewData]>();
-    const [sourcesViewData, setSourcesViewData] =
-        useState<[SamplerData, SourcesViewData]>();
+    const [flatViewData, setFlatViewData] = useState<{
+        data: SamplerData;
+        viewData: FlatViewData;
+    }>();
+    const [sourcesViewData, setSourcesViewData] = useState<{
+        data: SamplerData;
+        viewData: SourcesViewData;
+    }>();
 
     // Generate flat & sources view in the background on first load
     useEffect(() => {
@@ -85,15 +89,30 @@ export default function Sampler({
             const worker = await RemoteSamplerWorker.create(data);
 
             try {
+                const tasks: Promise<void>[] = [];
+
                 if (data.sources.hasSources()) {
-                    const sourcesView = await worker.generateSourcesView();
-                    if (cancelled) return;
-                    setSourcesViewData([data, sourcesView]);
+                    tasks.push(
+                        worker.generateSourcesView().then(viewData => {
+                            if (!cancelled) {
+                                setSourcesViewData({
+                                    data,
+                                    viewData,
+                                });
+                            }
+                        })
+                    );
                 }
 
-                const flatView = await worker.generateFlatView();
-                if (cancelled) return;
-                setFlatViewData([data, flatView]);
+                tasks.push(
+                    worker.generateFlatView().then(viewData => {
+                        if (!cancelled) {
+                            setFlatViewData({ data, viewData });
+                        }
+                    })
+                );
+
+                await Promise.all(tasks);
             } finally {
                 worker.close();
             }
@@ -212,14 +231,14 @@ export default function Sampler({
                         <AllView data={data} setLabelMode={setLabelMode} />
                     ) : view === VIEW_FLAT ? (
                         <FlatView
-                            data={flatViewData?.[0] ?? data}
-                            viewData={flatViewData?.[1]}
+                            data={flatViewData?.data ?? data}
+                            viewData={flatViewData?.viewData}
                             setLabelMode={setLabelMode}
                         />
                     ) : (
                         <SourcesView
-                            data={sourcesViewData?.[0] ?? data}
-                            viewData={sourcesViewData?.[1]}
+                            data={sourcesViewData?.data ?? data}
+                            viewData={sourcesViewData?.viewData}
                             setLabelMode={setLabelMode}
                         />
                     )}

--- a/src/viewer/sampler/components/Sampler.tsx
+++ b/src/viewer/sampler/components/Sampler.tsx
@@ -71,17 +71,12 @@ export default function Sampler({
         false
     );
 
-    const [flatViewData, setFlatViewData] = useState<FlatViewData>();
-    const [sourcesViewData, setSourcesViewData] = useState<SourcesViewData>();
-
-    // views hold node ids so drop them when replacing the data
-    // otherwise the ids may resolve to nodes from the new map
-    const [previousData, setPreviousData] = useState(data);
-    if (previousData != data) {
-        setPreviousData(data);
-        setFlatViewData(undefined);
-        setSourcesViewData(undefined);
-    }
+    // views reference nodes by id so keep them tied to their data
+    // otherwise old ids gets resolved against the new node map
+    const [flatViewData, setFlatViewData] =
+        useState<[SamplerData, FlatViewData]>();
+    const [sourcesViewData, setSourcesViewData] =
+        useState<[SamplerData, SourcesViewData]>();
 
     // Generate flat & sources view in the background on first load
     useEffect(() => {
@@ -93,12 +88,12 @@ export default function Sampler({
                 if (data.sources.hasSources()) {
                     const sourcesView = await worker.generateSourcesView();
                     if (cancelled) return;
-                    setSourcesViewData(sourcesView);
+                    setSourcesViewData([data, sourcesView]);
                 }
 
                 const flatView = await worker.generateFlatView();
                 if (cancelled) return;
-                setFlatViewData(flatView);
+                setFlatViewData([data, flatView]);
             } finally {
                 worker.close();
             }
@@ -217,14 +212,14 @@ export default function Sampler({
                         <AllView data={data} setLabelMode={setLabelMode} />
                     ) : view === VIEW_FLAT ? (
                         <FlatView
-                            data={data}
-                            viewData={flatViewData}
+                            data={flatViewData?.[0] ?? data}
+                            viewData={flatViewData?.[1]}
                             setLabelMode={setLabelMode}
                         />
                     ) : (
                         <SourcesView
-                            data={data}
-                            viewData={sourcesViewData}
+                            data={sourcesViewData?.[0] ?? data}
+                            viewData={sourcesViewData?.[1]}
                             setLabelMode={setLabelMode}
                         />
                     )}

--- a/src/viewer/sampler/components/Sampler.tsx
+++ b/src/viewer/sampler/components/Sampler.tsx
@@ -74,21 +74,38 @@ export default function Sampler({
     const [flatViewData, setFlatViewData] = useState<FlatViewData>();
     const [sourcesViewData, setSourcesViewData] = useState<SourcesViewData>();
 
+    // views hold node ids so drop them when replacing the data
+    // otherwise the ids may resolve to nodes from the new map
+    const [previousData, setPreviousData] = useState(data);
+    if (previousData != data) {
+        setPreviousData(data);
+        setFlatViewData(undefined);
+        setSourcesViewData(undefined);
+    }
+
     // Generate flat & sources view in the background on first load
     useEffect(() => {
+        let cancelled = false;
         (async () => {
             const worker = await RemoteSamplerWorker.create(data);
 
-            if (data.sources.hasSources()) {
-                const sourcesView = await worker.generateSourcesView();
-                setSourcesViewData(sourcesView);
+            try {
+                if (data.sources.hasSources()) {
+                    const sourcesView = await worker.generateSourcesView();
+                    if (cancelled) return;
+                    setSourcesViewData(sourcesView);
+                }
+
+                const flatView = await worker.generateFlatView();
+                if (cancelled) return;
+                setFlatViewData(flatView);
+            } finally {
+                worker.close();
             }
-
-            const flatView = await worker.generateFlatView();
-            setFlatViewData(flatView);
-
-            worker.close();
         })();
+        return () => {
+            cancelled = true;
+        };
     }, [data]);
 
     // WebSocket


### PR DESCRIPTION
Opening a live profile in the sources view blows up after about a minute:
<img width="1135" height="55" alt="image" src="https://github.com/user-attachments/assets/baf7284b-6c08-477e-a017-35147324757b" />

To hit it: `/spark profiler open`, sources view, wait for the next update.

The generated views refers to nodes by id, and ids are indexes into `NodeMap.allNodes`, so they only mean something for the data they came from.
An update swaps the data while the old view is still rendered on screen, so the old ids get resolved against the new node map and turn undefined.

First commit discards views when the data changes. That stopped the crash but hit the user with the loading page at every refresh.
The second commit keeps each view paired with the data it came from so views can just refresh with their proper data.

Tested on a live profile against a running production server.